### PR TITLE
ToAction()/ToFunc() return MatcherFunc directly

### DIFF
--- a/Patterns/Matcher.cs
+++ b/Patterns/Matcher.cs
@@ -99,7 +99,7 @@ namespace Patterns
         /// </summary>
         public Action<T> ToAction()
         {
-            return Match;
+            return MatcherFunc;
         }
 
         /// <summary>
@@ -211,7 +211,7 @@ namespace Patterns
         /// </summary>
         public Func<TIn, TOut> ToFunc()
         {
-            return Match;
+            return MatcherFunc;
         }
 
         /// <summary>


### PR DESCRIPTION
 instead of creating wrapping delegate

Motivation:
Currently call to `ToAction` creates a new delegate that wraps call to `Match`. As a result, invocation of this delegate results in a call to `Match` that in turn invokes `MatcherFunc`. There is a penalty of this extra hop - 40% for a simple case of `{m => m as T, m => x(m)}` matching.

Modification:
`ToAction()` / `ToFunc` return `MatcherFunc` directly

Result:
perf boost
